### PR TITLE
Added MIT license field for all rust crates

### DIFF
--- a/rust/gadgets-common/Cargo.toml
+++ b/rust/gadgets-common/Cargo.toml
@@ -2,6 +2,7 @@
 name = "gadgets-common"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/gadgets-scfs/Cargo.toml
+++ b/rust/gadgets-scfs/Cargo.toml
@@ -5,6 +5,7 @@ repository = "https://github.com/FrankC01/solana-gadgets/tree/main/rust"
 categories = ["command-line-utilities", "solana"]
 version = "0.2.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/sad/Cargo.toml
+++ b/rust/sad/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sad"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/scfs-program/Cargo.toml
+++ b/rust/scfs-program/Cargo.toml
@@ -2,6 +2,7 @@
 name = "scfs-program"
 version = "0.1.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/rust/scfsd/Cargo.toml
+++ b/rust/scfsd/Cargo.toml
@@ -5,6 +5,7 @@ repository = "https://github.com/FrankC01/solana-gadgets/tree/main/rust"
 categories = ["command-line-utilities", "solana"]
 version = "0.2.0"
 edition = "2021"
+license = "MIT"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
Hi, I have an github workflow that uses the cargo_deny crate and it's failing since the rust crates don't specify the license field in the `Cargo.toml`. I added the MIT license since that was listed under the root directory of your repo. Please let me know if this is okay or if there's any reason you wouldn't want to add this.

Thank you so much for your tools as well as your other repos!